### PR TITLE
Don't install to /usr/local

### DIFF
--- a/com.github.mirkobrombin.football
+++ b/com.github.mirkobrombin.football
@@ -24,10 +24,7 @@ import sys
 launch_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
 
 # Update sys.path to include modules
-if launch_dir == "/usr/bin":
-    modules_path = "/usr/share/com.github.mirkobrombin.football/football"
-else:
-    modules_path = launch_dir + "/football"
+modules_path = "/usr/share/com.github.mirkobrombin.football/football"
 
 sys.path.insert(0, modules_path)
 

--- a/debian/install
+++ b/debian/install
@@ -1,9 +1,0 @@
-football /usr/local/bin/
-football /usr/share/com.github.mirkobrombin.football/football
-setup.py /usr/share/com.github.mirkobrombin.football
-com.github.mirkobrombin.football /usr/local/bin
-com.github.mirkobrombin.football /usr/share/com.github.mirkobrombin.football
-data /usr/share/com.github.mirkobrombin.football
-data/com.github.mirkobrombin.football.svg /usr/local/share/icons/hicolor/128x128/apps
-data/com.github.mirkobrombin.football.desktop /usr/local/share/applications
-

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-cd /usr/share/com.github.mirkobrombin.football
-sudo python3 setup.py install

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,5 @@
 
 export PYBUILD_INSTALL_ARGS ?= --install-lib=/usr/share/com.github.mirkobrombin.football
 
-override_dh_usrlocal:
-	
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
`/usr/local` is for things manually installed "by the system administrator". See the [Filesystem Hierarchy Standard](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for more info about what goes where on a linux/unix system.

I'm not a Python programmer by any means, but regarding `modules_path`, I think it would make much more sense to get this path from some variable instead of hardcoding it. Probably whatever `--install-lib` is set to if possible.